### PR TITLE
Add APIGATEWAY as S3EventSource

### DIFF
--- a/aws/logs_monitoring/steps/enums.py
+++ b/aws/logs_monitoring/steps/enums.py
@@ -75,6 +75,8 @@ class AwsS3EventSourceKeyword(Enum):
     WAF_0 = ("aws-waf-logs", AwsEventSource.WAF)
     WAF_1 = ("waflogs", AwsEventSource.WAF)
 
+    # e.g. 2024/06/12/08/amazon-apigateway-<firehose-ds-name>-2-2024-06-12-08-45-12-796e56c0-7fdf-47b7-9268-38b875bb62d2
+    APIGATEWAY = ("amazon-apigateway", AwsEventSource.APIGATEWAY)
     BEDROCK = ("bedrock", AwsEventSource.BEDROCK)
     # e.g. carbon-black-cloud-forwarder/alerts/org_key=*****/year=2021/month=7/day=19/hour=18/minute=15/second=41/8436e850-7e78-40e4-b3cd-6ebbc854d0a2.jsonl.gz
     CARBONBLACK = ("carbon-black", AwsEventSource.CARBONBLACK)


### PR DESCRIPTION
One of the supported flows for storing API Gateway Access Logs, is by sending logs to an S3 bucket via Firehose Delivery Streams. The name of the delivery stream always needs to start with `amazon-apigateway-`, which means the object keys in S3 will also have this string.

Currently, the forwarder doesn't support API Gateway as an S3EventSource, which means the `host` and `service` for the logs will be set to `s3`.

<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Adding API GW as a valid event source for logs stored in S3.

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
